### PR TITLE
Update version to support IntelliJ 2024.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.t45k"
-version = "1.0.3"
+version = "1.0.4"
 
 repositories {
     mavenCentral()
@@ -46,7 +46,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231")
-        untilBuild.set("233.*")
+        untilBuild.set("241.*")
     }
 
     signPlugin {


### PR DESCRIPTION
To support the latest IntelliJ (2024.1), I updated versions
* version of plugin itself
* version of `untilBuild` from 233 to 241

※ This is my first time creating a PR for someone else's repository, so I apologize if I have done anything amiss.

Thank you very much.